### PR TITLE
修正 index.html flatpickr 無法使用問題

### DIFF
--- a/app/frontend/packs/datapicker.js
+++ b/app/frontend/packs/datapicker.js
@@ -1,8 +1,6 @@
 import flatpickr from 'flatpickr'
 import { MandarinTraditional } from "flatpickr/dist/l10n/zh-tw"
 
-console.log(MandarinTraditional)
-
 document.addEventListener('turbolinks:load', () => {
   flatpickr.localize(MandarinTraditional)
 
@@ -10,6 +8,6 @@ document.addEventListener('turbolinks:load', () => {
 
   flatpickr('#end_date', {
     defaultDate: "today",
-    maxDate: "today",
+    maxDate: "today"
   })
 })

--- a/app/frontend/packs/transactions.js
+++ b/app/frontend/packs/transactions.js
@@ -1,14 +1,15 @@
-import flatpickr from 'flatpickr'; // 別人的函式庫先上面，在放自己的js檔
-import $ from "jquery";
-// import '../sweetalert.js';
+import flatpickr from 'flatpickr'
+import { MandarinTraditional } from "flatpickr/dist/l10n/zh-tw"
 
-$(document).on('turbolinks:load', function() {
-  $('#start_date').off('click')
-                  .on('click', function() {
-                    flatpickr('#start_date', {})
-                  });
-  $('#end_date').off('click')
-                .on('click', function() {
-                  flatpickr('#end_date', {})
-                });
+console.log(MandarinTraditional)
+
+document.addEventListener('turbolinks:load', () => {
+  flatpickr.localize(MandarinTraditional)
+
+  flatpickr('#start_date', {})
+
+  flatpickr('#end_date', {
+    defaultDate: "today",
+    maxDate: "today",
+  })
 })

--- a/app/views/users/transactions/index.html.erb
+++ b/app/views/users/transactions/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :scripts do %>
-  <%= javascript_pack_tag 'transactions' %>
+  <%= javascript_pack_tag 'datapicker', 'data-turbolinks-track': 'reload' %>
 <% end %>
 
 <div class="container">

--- a/app/views/users/transactions/new.html.erb
+++ b/app/views/users/transactions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :scripts do %>
-  <%= javascript_pack_tag 'qrcodescanner' %>
+  <%= javascript_pack_tag 'qrcodescanner', 'data-turbolinks-track': 'reload' %>
 <% end %>
 <div class="container">
   <h1 class='new-title'><i class="fas fa-plus"></i>新增帳目</h1>


### PR DESCRIPTION
1. 修正 input 點選後沒有日期選擇器顯示問題
2. 設定 flatpickr 語言至繁體中文
3. 新增 turbolinks reload 至 `content_for` script 標籤
4. 原 `app/frontend/packs/transactions.js` 改檔名成 `datepicker.js`

以上說明。