### PR TITLE
Add transactions amount default value : 0

### DIFF
--- a/db/migrate/20200108073615_add_transactions_amount_default.rb
+++ b/db/migrate/20200108073615_add_transactions_amount_default.rb
@@ -1,0 +1,5 @@
+class AddTransactionsAmountDefault < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :transactions, :amount, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_02_055653) do
+ActiveRecord::Schema.define(version: 2020_01_08_073615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 2020_01_02_055653) do
   create_table "transactions", force: :cascade do |t|
     t.string "invoice_num"
     t.string "invoice_photo"
-    t.decimal "amount"
+    t.decimal "amount", default: "0.0"
     t.bigint "user_id", null: false
     t.integer "status"
     t.jsonb "data"


### PR DESCRIPTION
增加Transaction Items Amont欄位的預設值為0，以利結餘功能正常運作。
請確認是否無誤，謝謝。